### PR TITLE
feat: eth_call implementation

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ use clap::{Parser, Subcommand};
 use hex;
 use serde_json::{self, json};
 use std::collections::HashMap;
+use std::collections::HashSet;
 use std::str::FromStr;
 use std::sync::Arc;
 use tokio::sync::Mutex;
@@ -133,7 +134,7 @@ struct StoredTransaction {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum IntentStatus {
     Submitted,
-    Locked,
+    Locked(Address),
     Solved,
 }
 
@@ -291,6 +292,7 @@ struct CoreLaneState {
     genesis_block: CoreLaneBlock,         // Genesis block
     intents: HashMap<B256, Intent>,
     bitcoin_client: Arc<Client>,
+    stored_blobs: HashSet<B256>,
 }
 
 impl CoreLaneState {
@@ -328,6 +330,7 @@ impl CoreLaneNode {
             genesis_block,
             intents: HashMap::new(),
             bitcoin_client: bitcoin_client.clone(),
+            stored_blobs: HashSet::new(),
         }));
 
         Self {

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -732,7 +732,7 @@ fn execute_transfer(
                 if let Some(intent) = state.intents.get_mut(&intent_id) {
                     match intent.status {
                         IntentStatus::Submitted => {
-                            intent.status = IntentStatus::Locked;
+                            intent.status = IntentStatus::Locked(sender);
                             let _ = state.account_manager.increment_nonce(sender);
                             return Ok(ExecutionResult {
                                 success: true,
@@ -743,7 +743,7 @@ fn execute_transfer(
                                 error: None,
                             });
                         }
-                        IntentStatus::Locked => {
+                        IntentStatus::Locked(_) => {
                             return Ok(ExecutionResult {
                                 success: false,
                                 gas_used,
@@ -781,7 +781,7 @@ fn execute_transfer(
                 );
 
                 if let Some(intent) = state.intents.get(&intent_id) {
-                    if !matches!(intent.status, IntentStatus::Locked) {
+                    if !matches!(intent.status, IntentStatus::Locked(_)) {
                         return Ok(ExecutionResult {
                             success: false,
                             gas_used,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * RPC now returns concrete 0x‑prefixed hex results for call-style intent queries (status, value, locker).
  * State tracks stored blob identifiers, enabling retrieval and validation.
  * Intent locking records the locker’s address, accessible via queries.

* Behavior Changes
  * “Locked” intent status now includes the locker’s address.
  * Invalid call parameters now yield clear JSON-RPC errors instead of “not implemented.”

* Reliability
  * More robust handling of intent queries with deterministic fallback data for unsupported calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->