### PR TITLE
cleanup: CoreMEL -> CoreLane

### DIFF
--- a/src/account.rs
+++ b/src/account.rs
@@ -4,14 +4,14 @@ use std::collections::HashMap;
 
 /// Core Lane account structure
 #[derive(Debug, Clone)]
-pub struct CoreMELAccount {
+pub struct CoreLaneAccount {
     pub balance: U256,
     pub nonce: U256,
     pub code: Bytes,
     pub storage: HashMap<B256, B256>,
 }
 
-impl CoreMELAccount {
+impl CoreLaneAccount {
     pub fn new() -> Self {
         Self {
             balance: U256::ZERO,
@@ -73,7 +73,7 @@ impl CoreMELAccount {
 /// Account manager for Core Lane
 #[derive(Debug, Clone)]
 pub struct AccountManager {
-    accounts: HashMap<Address, CoreMELAccount>,
+    accounts: HashMap<Address, CoreLaneAccount>,
 }
 
 impl AccountManager {
@@ -83,14 +83,14 @@ impl AccountManager {
         }
     }
 
-    pub fn get_account(&self, address: Address) -> Option<&CoreMELAccount> {
+    pub fn get_account(&self, address: Address) -> Option<&CoreLaneAccount> {
         self.accounts.get(&address)
     }
 
-    pub fn get_account_mut(&mut self, address: Address) -> &mut CoreMELAccount {
+    pub fn get_account_mut(&mut self, address: Address) -> &mut CoreLaneAccount {
         self.accounts
             .entry(address)
-            .or_insert_with(CoreMELAccount::new)
+            .or_insert_with(CoreLaneAccount::new)
     }
 
     pub fn get_balance(&self, address: Address) -> U256 {
@@ -158,7 +158,7 @@ impl AccountManager {
             .unwrap_or(false)
     }
 
-    pub fn get_all_accounts(&self) -> &HashMap<Address, CoreMELAccount> {
+    pub fn get_all_accounts(&self) -> &HashMap<Address, CoreLaneAccount> {
         &self.accounts
     }
 

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -331,9 +331,9 @@ fn get_transaction_nonce(tx: &TxEnvelope) -> u64 {
 
 /// Core Lane specific addresses for special operations
 #[derive(Debug, Clone)]
-pub struct CoreMELAddresses;
+pub struct CoreLaneAddresses;
 
-impl CoreMELAddresses {
+impl CoreLaneAddresses {
     /// Burn address: 0x000000000000000000000000000000000000dead
     pub fn burn() -> Address {
         Address::from([
@@ -661,7 +661,7 @@ fn execute_transfer(
         }
     };
 
-    if to == CoreMELAddresses::exit_marketplace() {
+    if to == CoreLaneAddresses::exit_marketplace() {
         let input = Bytes::from(get_transaction_input_bytes(tx));
         let nonce = get_transaction_nonce(tx);
         if input.len() < 4 {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Renamed core account and address types across the public API for consistency.
  - Updated account management methods and accessors to use the new types.
  - This is a breaking change; client integrations must update references to the renamed types.

- Documentation
  - Updated API references to reflect the new type names.

- Chores
  - General cleanup to align internal usage with the new naming convention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->