### PR TITLE
add zero_base_fee for derived lanes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -507,7 +507,7 @@ dependencies = [
  "foldhash 0.2.0",
  "getrandom 0.4.2",
  "hashbrown 0.16.1",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "itoa",
  "k256",
  "keccak-asm",
@@ -588,9 +588,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rlp"
-version = "0.3.13"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e93e50f64a77ad9c5470bf2ad0ca02f228da70c792a8f06634801e202579f35e"
+checksum = "dc90b1e703d3c03f4ff7f48e82dd0bc1c8211ab7d079cd836a06fcfeb06651cb"
 dependencies = [
  "alloy-rlp-derive",
  "arrayvec",
@@ -599,9 +599,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rlp-derive"
-version = "0.3.13"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce8849c74c9ca0f5a03da1c865e3eb6f768df816e67dd3721a398a8a7e398011"
+checksum = "f36834a5c0a2fa56e171bf256c34d70fca07d0c0031583edea1c4946b7889c9e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -777,7 +777,7 @@ dependencies = [
  "alloy-sol-macro-input",
  "const-hex",
  "heck 0.5.0",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "proc-macro-error2",
  "proc-macro2",
  "quote",
@@ -3036,9 +3036,9 @@ dependencies = [
 
 [[package]]
 name = "cmov"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de0758edba32d61d1fd9f4d69491b47604b91ee2f7e6b33de7e54ca4ebe55dc3"
+checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
 
 [[package]]
 name = "coins-bip32"
@@ -3654,9 +3654,9 @@ dependencies = [
 
 [[package]]
 name = "ctutils"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1005a6d4446f5120ef475ad3d2af2b30c49c2c9c6904258e3bb30219bebed5e4"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
 dependencies = [
  "cmov",
 ]
@@ -4455,7 +4455,7 @@ dependencies = [
  "hotshot-query-service",
  "hotshot-types",
  "humantime",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "insta",
  "itertools 0.12.1",
  "jf-advz",
@@ -5115,7 +5115,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "slab",
  "tokio",
  "tokio-util",
@@ -5134,7 +5134,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.4.0",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "slab",
  "tokio",
  "tokio-util",
@@ -6104,12 +6104,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -6117,9 +6118,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -6130,9 +6131,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -6144,15 +6145,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -6164,15 +6165,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -6340,9 +6341,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
@@ -7524,9 +7525,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "local-ip-address"
@@ -8776,9 +8777,9 @@ dependencies = [
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -8838,7 +8839,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.25.9+spec-1.1.0",
+ "toml_edit 0.25.10+spec-1.1.0",
 ]
 
 [[package]]
@@ -10573,7 +10574,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "schemars 0.9.0",
  "schemars 1.2.1",
  "serde_core",
@@ -11034,7 +11035,7 @@ dependencies = [
  "hashbrown 0.14.5",
  "hashlink 0.9.1",
  "hex",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "log",
  "memchr",
  "native-tls",
@@ -11861,9 +11862,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -11886,9 +11887,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "2bd1c4c0fc4a7ab90fc15ef6daaa3ec3b893f004f915f2392557ed23237820cd"
 dependencies = [
  "bytes 1.11.1",
  "libc",
@@ -11904,9 +11905,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12036,7 +12037,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "serde",
  "serde_spanned",
  "toml_datetime 0.6.11",
@@ -12046,11 +12047,11 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.9+spec-1.1.0"
+version = "0.25.10+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da053d28fe57e2c9d21b48261e14e7b4c8b670b54d2c684847b91feaf4c7dac5"
+checksum = "a82418ca169e235e6c399a84e395ab6debeb3bc90edc959bf0f48647c6a32d1b"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "winnow 1.0.1",
@@ -12058,9 +12059,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.1.1+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39ca317ebc49f06bd748bfba29533eac9485569dc9bf80b849024b025e814fb9"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
  "winnow 1.0.1",
 ]
@@ -12888,7 +12889,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -12914,7 +12915,7 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags 2.11.0",
  "hashbrown 0.15.5",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "semver 1.0.27",
 ]
 
@@ -13538,7 +13539,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "prettyplease",
  "syn 2.0.117",
  "wasm-metadata",
@@ -13569,7 +13570,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags 2.11.0",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "log",
  "serde",
  "serde_derive",
@@ -13588,7 +13589,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.13.0",
+ "indexmap 2.13.1",
  "log",
  "semver 1.0.27",
  "serde",
@@ -13600,9 +13601,9 @@ dependencies = [
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "ws_stream_wasm"
@@ -13720,9 +13721,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -13731,9 +13732,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -13763,18 +13764,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -13804,9 +13805,9 @@ dependencies = [
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -13815,9 +13816,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -13826,9 +13827,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/src/eip1559.rs
+++ b/src/eip1559.rs
@@ -26,10 +26,11 @@ pub struct Eip1559Config {
 impl Eip1559Config {
     /// Configuration for derived lanes that do not charge a base (burn) fee on-chain.
     pub fn derived_lane_zero_base_fee() -> Self {
-        let mut c = Self::default();
-        c.zero_base_fee = true;
-        c.initial_base_fee = U256::ZERO;
-        c
+        Self {
+            zero_base_fee: true,
+            initial_base_fee: U256::ZERO,
+            ..Default::default()
+        }
     }
 }
 

--- a/src/eip1559.rs
+++ b/src/eip1559.rs
@@ -17,6 +17,20 @@ pub struct Eip1559Config {
     pub base_fee_change_denominator: U256,
     /// Elasticity multiplier (typically 2)
     pub elasticity_multiplier: U256,
+    /// When true, base fee is fixed at zero: no L2 gas-token burn; sequencing is paid on the
+    /// sequencer / data-availability layer (e.g. derived lanes without a native gas token).
+    #[serde(default)]
+    pub zero_base_fee: bool,
+}
+
+impl Eip1559Config {
+    /// Configuration for derived lanes that do not charge a base (burn) fee on-chain.
+    pub fn derived_lane_zero_base_fee() -> Self {
+        let mut c = Self::default();
+        c.zero_base_fee = true;
+        c.initial_base_fee = U256::ZERO;
+        c
+    }
 }
 
 impl Default for Eip1559Config {
@@ -28,6 +42,7 @@ impl Default for Eip1559Config {
             target_gas_usage: U256::from(15_000_000u64),    // 15M gas (50% of limit)
             base_fee_change_denominator: U256::from(8u64),
             elasticity_multiplier: U256::from(2u64),
+            zero_base_fee: false,
         }
     }
 }
@@ -54,8 +69,13 @@ impl Eip1559FeeManager {
     /// Create a new EIP-1559 fee manager with custom configuration
     #[allow(dead_code)]
     pub fn with_config(config: Eip1559Config) -> Self {
+        let current_base_fee = if config.zero_base_fee {
+            U256::ZERO
+        } else {
+            config.initial_base_fee
+        };
         Self {
-            current_base_fee: config.initial_base_fee,
+            current_base_fee,
             config,
         }
     }
@@ -70,6 +90,9 @@ impl Eip1559FeeManager {
     /// base_fee = parent_base_fee + parent_base_fee * gas_used_delta / parent_gas_limit / base_fee_change_denominator
     /// where gas_used_delta = parent_gas_used - parent_gas_target
     pub fn calculate_next_base_fee(&self, gas_used: U256) -> U256 {
+        if self.config.zero_base_fee {
+            return U256::ZERO;
+        }
         let parent_base_fee = self.current_base_fee;
         let _parent_gas_limit = self.config.gas_limit;
         let parent_gas_target = self.config.target_gas_usage;
@@ -236,6 +259,9 @@ impl Eip1559FeeManager {
     #[allow(dead_code)]
     pub fn update_config(&mut self, config: Eip1559Config) {
         self.config = config;
+        if self.config.zero_base_fee {
+            self.current_base_fee = U256::ZERO;
+        }
     }
 
     /// Get the maximum block gas limit (EIP-1559 maximum)
@@ -355,5 +381,19 @@ mod tests {
         assert_eq!(base_fee_portion, base_fee * gas_limit);
         assert_eq!(priority_fee_portion, priority_fee * gas_limit);
         assert_eq!(total_fee, base_fee_portion + priority_fee_portion);
+    }
+
+    #[test]
+    fn test_zero_base_fee_stays_zero() {
+        let config = Eip1559Config::derived_lane_zero_base_fee();
+        let mut manager = Eip1559FeeManager::with_config(config);
+        assert_eq!(manager.current_base_fee(), U256::ZERO);
+        let high_gas = manager.config().gas_limit;
+        let next = manager.update_base_fee(1, high_gas);
+        assert_eq!(next, U256::ZERO);
+        assert_eq!(manager.current_base_fee(), U256::ZERO);
+        assert!(manager
+            .validate_eip1559_transaction(U256::ZERO, U256::ZERO, U256::from(21_000u64))
+            .is_ok());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,7 +48,8 @@ impl MetaState {
 
 /// Version byte for tip file format. Enables schema evolution; change when ChainTip/CoreLaneBlock layout changes.
 /// When this is bumped, any existing tip file will be treated as invalid and all block data (blocks/, metastate/, deltas/, chain_index/, tip) will be wiped so the node starts from genesis.
-const TIP_FORMAT_VERSION: u8 = 5;
+/// v6: EIP-1559 `Eip1559Config` includes `zero_base_fee` (bincode metastate layout).
+const TIP_FORMAT_VERSION: u8 = 6;
 
 /// Persisted chain tip for restore-from-disk on startup.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -315,6 +316,9 @@ enum Commands {
         /// When enabled, block scanning only occurs when triggered via POST /do_poll endpoint
         #[arg(long)]
         on_demand_polling: bool,
+        /// Fix base fee at zero (no L2 burn); for derived lanes where DA/sequencer carries cost
+        #[arg(long)]
+        zero_base_fee: bool,
     },
 
     Burn {
@@ -512,6 +516,9 @@ enum Commands {
         /// When enabled, block scanning only occurs when triggered via POST /do_poll endpoint
         #[arg(long)]
         on_demand_polling: bool,
+        /// Fix base fee at zero (no L2 burn); for derived lanes where DA/sequencer carries cost
+        #[arg(long)]
+        zero_base_fee: bool,
     },
     /// Start a derived Core Lane node that reads bundles from an Espresso.
     DerivedEspressoStart {
@@ -544,6 +551,9 @@ enum Commands {
         /// If not provided, defaults to a well-known test address (insecure for production)
         #[arg(long)]
         sequencer_address: Option<String>,
+        /// Fix base fee at zero (no L2 burn); for derived lanes where DA/sequencer carries cost
+        #[arg(long)]
+        zero_base_fee: bool,
     },
 }
 
@@ -886,6 +896,14 @@ struct CoreLaneNode {
     core_lane_rpc_url: Option<String>,
 }
 
+fn eip1559_config_from_flag(zero_base_fee: bool) -> eip1559::Eip1559Config {
+    if zero_base_fee {
+        eip1559::Eip1559Config::derived_lane_zero_base_fee()
+    } else {
+        eip1559::Eip1559Config::default()
+    }
+}
+
 impl CoreLaneNode {
     fn new(
         bitcoin_client_read: Arc<dyn BitcoinRpcReadClient>,
@@ -894,6 +912,7 @@ impl CoreLaneNode {
         data_dir: String,
         network: bitcoin::Network,
         sequencer_address: Option<Address>,
+        eip1559_config: eip1559::Eip1559Config,
     ) -> Self {
         Self::new_with_clients(
             Some(bitcoin_client_read),
@@ -902,6 +921,7 @@ impl CoreLaneNode {
             data_dir,
             network,
             sequencer_address,
+            eip1559_config,
         )
     }
 
@@ -909,8 +929,17 @@ impl CoreLaneNode {
         data_dir: String,
         network: bitcoin::Network,
         sequencer_address: Option<Address>,
+        eip1559_config: eip1559::Eip1559Config,
     ) -> Self {
-        Self::new_with_clients(None, None, None, data_dir, network, sequencer_address)
+        Self::new_with_clients(
+            None,
+            None,
+            None,
+            data_dir,
+            network,
+            sequencer_address,
+            eip1559_config,
+        )
     }
 
     fn new_with_clients(
@@ -920,9 +949,9 @@ impl CoreLaneNode {
         data_dir: String,
         network: bitcoin::Network,
         sequencer_address: Option<Address>,
+        eip1559_config: eip1559::Eip1559Config,
     ) -> Self {
-        // Create genesis block with EIP-1559 default configuration (always needed)
-        let eip1559_config = eip1559::Eip1559Config::default();
+        // Create genesis block with EIP-1559 configuration (always needed)
         let genesis_block =
             CoreLaneBlock::genesis(eip1559_config.gas_limit, eip1559_config.initial_base_fee);
         let genesis_hash = genesis_block.hash;
@@ -1039,7 +1068,7 @@ impl CoreLaneNode {
                 genesis_block: genesis_block.clone(),
                 bitcoin_client_read: bitcoin_client_read.clone(),
                 bitcoin_client_write: bitcoin_client_write.clone(),
-                eip1559_fee_manager: eip1559::Eip1559FeeManager::new(),
+                eip1559_fee_manager: eip1559::Eip1559FeeManager::with_config(eip1559_config.clone()),
                 sequencer_address: sequencer_addr,
                 total_burned_amount: U256::ZERO,
                 bitcoin_network: network,
@@ -1053,7 +1082,7 @@ impl CoreLaneNode {
 
         // Write genesis state to disk only when we did not restore (so we don't overwrite existing state)
         if !restored {
-            if let Err(e) = Self::write_genesis_state(&data_dir, sequencer_addr) {
+            if let Err(e) = Self::write_genesis_state(&data_dir, sequencer_addr, &eip1559_config) {
                 error!("Failed to write genesis state to disk: {}", e);
             }
         }
@@ -1472,7 +1501,11 @@ impl CoreLaneNode {
     }
 
     /// Write the genesis state (block 0) to disk
-    pub fn write_genesis_state(data_dir: &str, sequencer_address: Address) -> Result<()> {
+    pub fn write_genesis_state(
+        data_dir: &str,
+        sequencer_address: Address,
+        eip1559_config: &eip1559::Eip1559Config,
+    ) -> Result<()> {
         use std::fs;
         use std::path::Path;
 
@@ -1499,7 +1532,7 @@ impl CoreLaneNode {
 
         // Create initial metastate for genesis block
         let genesis_metastate = MetaState {
-            eip1559_fee_manager: eip1559::Eip1559FeeManager::new(),
+            eip1559_fee_manager: eip1559::Eip1559FeeManager::with_config(eip1559_config.clone()),
             total_burned_amount: U256::ZERO,
             sequencer_address,
         };
@@ -2469,28 +2502,33 @@ impl CoreLaneNode {
                 total_fee, base_fee_portion, priority_fee_portion
             );
         } else if tx.0.is_legacy() {
-            // Legacy transaction handling (fallback to fixed gas price)
-            let gas_price = U256::from(214285714u64); // Fixed legacy gas price
-            let legacy_tx = tx.0.as_legacy().unwrap();
+            if state.eip1559_fee_manager.config().zero_base_fee {
+                // Align with EIP-1559 zero-fee mode: no on-chain L2 gas charge for derived lanes
+                info!("      💰 Legacy tx: zero base fee mode — no L2 gas charge");
+            } else {
+                let legacy_tx = tx.0.as_legacy().unwrap();
+                // Legacy transaction handling (fallback to fixed gas price)
+                let gas_price = U256::from(214285714u64); // Fixed legacy gas price
 
-            if gas_price > legacy_tx.tx().gas_price {
-                warn!(
-                    "      ⚠️  Gas fee is greater than the legacy transaction gas price, skipping: {:?}",
-                    tx.0
-                );
-                return None;
+                if gas_price > legacy_tx.tx().gas_price {
+                    warn!(
+                        "      ⚠️  Gas fee is greater than the legacy transaction gas price, skipping: {:?}",
+                        tx.0
+                    );
+                    return None;
+                }
+
+                let gas_fee = gas_price * gas_limit;
+                if let Err(e) = bundle_state.sub_balance(&state.account_manager, tx.1, gas_fee) {
+                    warn!(
+                        "      ⚠️  Failed to charge legacy gas fee: {}, skipping: {:?}",
+                        e, tx.0
+                    );
+                    return None;
+                }
+
+                info!("      💰 Charged legacy gas fee: {} wei", gas_fee);
             }
-
-            let gas_fee = gas_price * gas_limit;
-            if let Err(e) = bundle_state.sub_balance(&state.account_manager, tx.1, gas_fee) {
-                warn!(
-                    "      ⚠️  Failed to charge legacy gas fee: {}, skipping: {:?}",
-                    e, tx.0
-                );
-                return None;
-            }
-
-            info!("      💰 Charged legacy gas fee: {} wei", gas_fee);
         } else {
             warn!(
                 "      ⚠️  Unsupported transaction type, skipping: {:?}",
@@ -2551,7 +2589,12 @@ impl CoreLaneNode {
             (effective_price, gas_limit)
         } else if tx.0.is_legacy() {
             let legacy_tx = tx.0.as_legacy().unwrap();
-            (U256::from(legacy_tx.tx().gas_price), gas_limit)
+            let effective = if state.eip1559_fee_manager.config().zero_base_fee {
+                U256::ZERO
+            } else {
+                U256::from(legacy_tx.tx().gas_price)
+            };
+            (effective, gas_limit)
         } else {
             (U256::from(214285714u64), gas_limit) // Default fallback
         };
@@ -3311,6 +3354,7 @@ async fn main() -> Result<()> {
             sequencer_rpc_url,
             sequencer_address,
             on_demand_polling,
+            zero_base_fee,
         } => {
             // Parse sequencer address if provided
             let sequencer_addr = sequencer_address
@@ -3328,6 +3372,11 @@ async fn main() -> Result<()> {
                 );
             } else {
                 info!("✅ Using sequencer address: {:?}", sequencer_addr);
+            }
+
+            let eip1559_config = eip1559_config_from_flag(*zero_base_fee);
+            if *zero_base_fee {
+                info!("✅ EIP-1559 zero base fee mode (L2 burn disabled; use for derived lanes)");
             }
 
             // Resolve mnemonic from various sources (optional if sequencer_rpc_url is provided)
@@ -3421,6 +3470,7 @@ async fn main() -> Result<()> {
                         cli.data_dir.clone(),
                         network,
                         sequencer_addr,
+                        eip1559_config.clone(),
                     );
                     (Arc::clone(&node.state), None, None, None) // node_opt = None to skip block scanner
                 } else {
@@ -3474,6 +3524,7 @@ async fn main() -> Result<()> {
                         cli.data_dir.clone(),
                         network,
                         sequencer_addr,
+                        eip1559_config.clone(),
                     );
                     let shared_state = Arc::clone(&node.state);
                     let bitcoin_client_write = node
@@ -4042,6 +4093,7 @@ async fn main() -> Result<()> {
                 cli.data_dir.clone(),
                 network,
                 None,
+                eip1559::Eip1559Config::default(),
             );
             node.send_transaction_to_da(
                 raw_tx_hex,
@@ -4132,6 +4184,7 @@ async fn main() -> Result<()> {
                 cli.data_dir.clone(),
                 network,
                 None,
+                eip1559::Eip1559Config::default(),
             );
             node.send_bundle_to_da(
                 raw_tx_hex_vec.clone(),
@@ -4675,6 +4728,7 @@ async fn main() -> Result<()> {
             sequencer_rpc_url,
             sequencer_address,
             on_demand_polling,
+            zero_base_fee,
         } => {
             // Parse sequencer address if provided
             let sequencer_addr = sequencer_address
@@ -4694,8 +4748,17 @@ async fn main() -> Result<()> {
                 info!("✅ Using sequencer address: {:?}", sequencer_addr);
             }
 
-            let node =
-                CoreLaneNode::new_derived(cli.data_dir.clone(), Network::Regtest, sequencer_addr);
+            let eip1559_config = eip1559_config_from_flag(*zero_base_fee);
+            if *zero_base_fee {
+                info!("✅ EIP-1559 zero base fee mode (L2 burn disabled; use for derived lanes)");
+            }
+
+            let node = CoreLaneNode::new_derived(
+                cli.data_dir.clone(),
+                Network::Regtest,
+                sequencer_addr,
+                eip1559_config,
+            );
 
             let da_address = Address::from_str(derived_da_address).map_err(|err| {
                 anyhow::anyhow!(
@@ -4772,6 +4835,7 @@ async fn main() -> Result<()> {
             http_port,
             sequencer_rpc_url,
             sequencer_address,
+            zero_base_fee,
         } => {
             // Parse sequencer address if provided
             let sequencer_addr = sequencer_address
@@ -4796,8 +4860,17 @@ async fn main() -> Result<()> {
                 espresso_base_url
             );
 
-            let mut node =
-                CoreLaneNode::new_derived(cli.data_dir.clone(), Network::Regtest, sequencer_addr);
+            let eip1559_config = eip1559_config_from_flag(*zero_base_fee);
+            if *zero_base_fee {
+                info!("✅ EIP-1559 zero base fee mode (L2 burn disabled; use for derived lanes)");
+            }
+
+            let mut node = CoreLaneNode::new_derived(
+                cli.data_dir.clone(),
+                Network::Regtest,
+                sequencer_addr,
+                eip1559_config,
+            );
             node.core_lane_rpc_url = Some(core_lane_rpc_url.clone());
 
             let shared_state = Arc::clone(&node.state);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1068,7 +1068,9 @@ impl CoreLaneNode {
                 genesis_block: genesis_block.clone(),
                 bitcoin_client_read: bitcoin_client_read.clone(),
                 bitcoin_client_write: bitcoin_client_write.clone(),
-                eip1559_fee_manager: eip1559::Eip1559FeeManager::with_config(eip1559_config.clone()),
+                eip1559_fee_manager: eip1559::Eip1559FeeManager::with_config(
+                    eip1559_config.clone(),
+                ),
                 sequencer_address: sequencer_addr,
                 total_burned_amount: U256::ZERO,
                 bitcoin_network: network,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -275,6 +275,7 @@ mod integration_tests {
         if let Err(e) = crate::CoreLaneNode::write_genesis_state(
             temp_dir.to_str().unwrap(),
             test_sequencer_address,
+            &crate::eip1559::Eip1559Config::default(),
         ) {
             panic!("Failed to write genesis state: {}", e);
         }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a --zero-base-fee CLI flag to start nodes with an option to keep the base fee fixed at zero.

* **Breaking Changes**
  * Persisted tip file format version bumped; existing tip files will be reset during upgrade.

* **Refactor**
  * Transaction fee handling and receipt pricing updated to honor the zero-base-fee setting.
  * Genesis persistence now records the chosen EIP-1559 configuration.

* **Tests**
  * Added tests ensuring base fee stays zero and genesis persistence uses explicit EIP-1559 settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->